### PR TITLE
Fix binaryTargets renderer

### DIFF
--- a/lib/deserializer.ts
+++ b/lib/deserializer.ts
@@ -3,7 +3,8 @@ import {
   DataSource,
   EnvValue,
   DMMF,
-  GeneratorConfig
+  GeneratorConfig,
+  BinaryTargetsEnvValue
 } from '@prisma/generator-helper/dist';
 import { Field, Model } from './dmmf-extension';
 import { valueIs } from './utils';
@@ -126,8 +127,8 @@ function renderProvider(provider: ConnectorType | string): string {
 function renderOutput(path: string | null): string {
   return path ? `output = "${path}"` : '';
 }
-function renderBinaryTargets(binaryTargets?: string[]): string {
-  return binaryTargets?.length ? `binaryTargets = ${JSON.stringify(binaryTargets)}` : '';
+function renderBinaryTargets(binaryTargets?: BinaryTargetsEnvValue[]): string {
+  return binaryTargets?.length ? `binaryTargets = ${JSON.stringify(binaryTargets.map(binaryTarget => binaryTarget.value))}` : '';
 }
 function renderPreviewFeatures(previewFeatures: GeneratorConfig['previewFeatures']): string {
   return previewFeatures.length ? `previewFeatures = ${JSON.stringify(previewFeatures)}` : '';
@@ -167,7 +168,7 @@ function deserializeGenerator(generator: GeneratorConfig): string {
   return renderBlock('generator', name, [
     renderProvider(provider.value),
     renderOutput(output?.value || null),
-    renderBinaryTargets(binaryTargets as unknown as string[]),
+    renderBinaryTargets(binaryTargets),
     renderPreviewFeatures(previewFeatures)
   ]);
 }


### PR DESCRIPTION
Hello,

I was trying to setup a config for a multi-schema setup with your tools (which is pretty great !) but I had some issues with the binaryTargets output described as follow:

Schema input:
`binaryTargets   = ["native", "debian-openssl-1.1.x"]`

Desired output:
`binaryTargets   = ["native", "debian-openssl-1.1.x"]`

Actual output:
`binaryTargets = [{"fromEnvVar":null,"value":"native"},{"fromEnvVar":null,"value":"debian-openssl-1.1.x"}]`

To fix this issues I edited the binaryTargets renderer to map only on the value of the inputs.