### PR TITLE
Fix one letter named fields

### DIFF
--- a/lib/deserializer.ts
+++ b/lib/deserializer.ts
@@ -136,7 +136,7 @@ function renderPreviewFeatures(previewFeatures: GeneratorConfig['previewFeatures
 // This function will render a code block with suitable indenting
 function renderBlock(type: string, name: string, things: string[], documentation?: string): string {
   return `${renderDocumentation(documentation)}${type} ${name} {\n${things
-    .filter((thing) => thing.length > 1)
+    .filter((thing) => thing.length > 0)
     .map((thing) => `\t${thing}`)
     .join('\n')}\n}`;
 }


### PR DESCRIPTION
Hello,

I had an issue with one of my enums in my schema.prisma while mixing it with your tool. Described as follow:

Schema input:
```
enum collect_measure_unit {
	kg
	l
}
```

Desired output:
```
enum collect_measure_unit {
	kg
	l
}
```

Actual output:
```
enum collect_measure_unit {
	kg
}
```

To fix this issues I edited the block renderer and edit field length filter.

I am not sure if this will impact other behaviour, why in the first place was there a 1 and not 0 ?